### PR TITLE
Better token handling

### DIFF
--- a/ui/app/(app)/dashboard/page.tsx
+++ b/ui/app/(app)/dashboard/page.tsx
@@ -1,8 +1,7 @@
-export default function Example() {
+import { auth } from "@/lib/auth";
 
-  return (
-    <>
-      Hello World
-    </>
-  )
+export default async function Example() {
+  const session = await auth();
+
+  return <>Hello {session?.user?.name}</>;
 }

--- a/ui/i18n.ts
+++ b/ui/i18n.ts
@@ -2,8 +2,7 @@ import { auth } from "@/lib/auth";
 import { getRequestConfig } from "next-intl/server";
 
 export default getRequestConfig(async () => {
-  // Provide a static locale, fetch a user setting,
-  // read from `cookies()`, `headers()`, etc.
+  // Read locale from session
   const session = await auth();
   let locale = session?.locale;
 

--- a/ui/i18n.ts
+++ b/ui/i18n.ts
@@ -1,10 +1,11 @@
-import { headers } from "next/headers";
+import { auth } from "@/lib/auth";
 import { getRequestConfig } from "next-intl/server";
 
 export default getRequestConfig(async () => {
   // Provide a static locale, fetch a user setting,
   // read from `cookies()`, `headers()`, etc.
-  let locale = "de-DE";
+  const session = await auth();
+  let locale = session?.locale;
 
   return {
     locale,

--- a/ui/lib/api/index.ts
+++ b/ui/lib/api/index.ts
@@ -1,12 +1,29 @@
+import { decode } from "next-auth/jwt";
+import { cookies } from "next/headers";
 import createClient, { Middleware } from "openapi-fetch";
 import type { paths } from "./v1";
-import { auth } from "@/lib/auth";
 export * from "./types";
 
 const authMiddleware: Middleware = {
   async onRequest({ request }) {
-    const session = await auth();
-    request.headers.set("Authorization", `Bearer ${session?.accessToken}`);
+    // Build the cookie name
+    const cookieName =
+      process.env.NODE_ENV === "production"
+        ? "__Secure-authjs.session-token"
+        : "authjs.session-token";
+    // Retrieve our frontend auth cookie that contains the encrypted frontend
+    // token
+    const cookie = cookies().get(cookieName);
+
+    // Decode/decrypt the token to access the backend API token
+    const token = await decode({
+      token: cookie?.value,
+      secret: process.env.AUTH_SECRET ?? "",
+      salt: cookieName,
+    });
+
+    // Set the backend API token
+    request.headers.set("Authorization", `Bearer ${token?.backendAPIToken}`);
     return request;
   },
 };

--- a/ui/lib/auth.ts
+++ b/ui/lib/auth.ts
@@ -34,26 +34,52 @@ export const { handlers, auth } = NextAuth({
   ],
   callbacks: {
     authorized: async ({ auth }) => {
+      console.log(auth?.expires);
       return !!auth;
     },
     jwt: async ({ token, user, account }) => {
       if (account && account.access_token) {
-        // set access_token to the token payload
-        token.accessToken = account.access_token;
+        // We want to make the backend API token available to our server
+        // components, so we include them in the "token" that is used to
+        // authenticate backend/frontend.
+        //
+        // Note: While this means that the API token ends up in this token, the
+        // client will not be able to read it since it is encrypted on the
+        // client-side.
+        token.backendAPIToken = account.access_token;
+
+        // Sync the expiry of our backend token with the frontend token
+        token.exp = account.expires_at;
       }
 
       return token;
     },
     session: async ({ session, token, user }) => {
-      // If we want to make the accessToken available in components, then we have to explicitly forward it here.
-      // We also set up the user's locale
-      return { ...session, accessToken: token.accessToken };
+      return {
+        ...session,
+        user: {
+          // Until we have a proper user-info endpoint, just set a fake name
+          // here. We also use this opportunity to set the default locale
+          name: "Mr. Money",
+        },
+        locale: "de-DE",
+      };
     },
+  },
+  session: {
+    maxAge: 24 * 60 * 60,
   },
 });
 
 declare module "next-auth" {
   interface Session {
-    accessToken?: string;
+    backendAPIToken: string;
+    locale: string;
+  }
+}
+
+declare module "@auth/core/jwt" {
+  interface JWT {
+    backendAPIToken?: string;
   }
 }

--- a/ui/lib/auth.ts
+++ b/ui/lib/auth.ts
@@ -73,13 +73,18 @@ export const { handlers, auth } = NextAuth({
 
 declare module "next-auth" {
   interface Session {
-    backendAPIToken: string;
+    /**
+     * The user's locale.
+     */
     locale: string;
   }
 }
 
 declare module "@auth/core/jwt" {
   interface JWT {
+    /**
+     * This contains the API token for our backend services.
+     */
     backendAPIToken?: string;
   }
 }

--- a/ui/lib/auth.ts
+++ b/ui/lib/auth.ts
@@ -34,7 +34,6 @@ export const { handlers, auth } = NextAuth({
   ],
   callbacks: {
     authorized: async ({ auth }) => {
-      console.log(auth?.expires);
       return !!auth;
     },
     jwt: async ({ token, user, account }) => {


### PR DESCRIPTION
This PR adds better token handling on the server-side. It removes the backend API token from the `session`, since we do all calls on the server-side now, which is much cleaner. It also syncs the expiry of frontend and backend token (this fixes #467) and moves the locale to the user session.
